### PR TITLE
Clarify Waldtag timing for Familiengruppen

### DIFF
--- a/src/pages/gruppen.astro
+++ b/src/pages/gruppen.astro
@@ -16,13 +16,13 @@ import Layout from '../layouts/Layout.astro';
 	</section>
 
 	<section class="panel">
-		<h2>Familiengruppen · Lerchennest & Spatzennest</h2>
-		<p class="eyebrow">16 Kinder pro Gruppe · bis zu 4 Nestkinder (2 Jahre)</p>
-		<ul class="list">
-			<li>
-				<strong>Zeiten:</strong> Mo–Do 07:30–12:45/13:00 Uhr (mit Mittagessen), optional bis 15:15 Uhr; Fr (Waldtag)
-				07:30–12:30 Uhr ohne Mittagessen. Nestkinder: Mo–Do 07:30–12:00 Uhr.
-			</li>
+                <h2>Familiengruppen · Lerchennest & Spatzennest</h2>
+                <p class="eyebrow">16 Kinder pro Gruppe · bis zu 4 Nestkinder (2 Jahre)</p>
+                <ul class="list">
+                        <li>
+                                <strong>Zeiten:</strong> Mo–Do 07:30–12:45/13:00 Uhr (mit Mittagessen), optional bis 15:15 Uhr; Fr 07:30–12:30 Uhr ohne
+                                Mittagessen. Waldtag: Montagvormittag für die Familiengruppen. Nestkinder: Mo–Do 07:30–12:00 Uhr.
+                        </li>
 			<li>
 				<strong>Geborgenheit & Kontinuität:</strong> gleiche Bezugsgruppe und Bezugserzieherin von der Krippe bis zum
 				Schuleintritt.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const rhythm = [
 	{ label: '07:30', text: 'Ankommen & freies Spiel mit Naturmaterialien (Krippe & Familiengruppen)' },
 	{ label: '09:00', text: 'Morgenkreis mit Liedern und Reimen zur Jahreszeit' },
 	{ label: '09:30', text: 'Gemeinsames vollwertiges Frühstück' },
-	{ label: '10:00', text: 'Garten oder Wald: Bewegung, Sinneserfahrungen, Ruhe (Fr: Waldtag)' },
+        { label: '10:00', text: 'Garten oder Wald: Bewegung, Sinneserfahrungen, Ruhe (Mo: Waldtag)' },
 	{ label: '12:00', text: 'Abschlusslied und Abholung der Nestkinder (2 Jahre)' },
 	{ label: '12:45', text: 'Mittagessen & Märchen/Tischpuppenspiel für die Größeren' },
 	{ label: '15:15', text: 'Optional: Nachmittagsbetreuung (Mo–Do) mit ruhigem Spiel & Gartenzeit' },
@@ -52,7 +52,7 @@ const rhythm = [
 			<ul class="tags">
 				<li>Familiengruppen (2–6 Jahre)</li>
 				<li>Krippe Wiegenstube (1–3 Jahre)</li>
-				<li>Waldtag am Freitag</li>
+                                <li>Waldtag am Montag</li>
 			</ul>
 		</div>
 		<div class="panel">


### PR DESCRIPTION
## Summary
- update Familiengruppen schedule so Friday remains the short day
- note that the Waldtag now takes place on Monday morning within the Familiengruppen

## Affected pages
- /gruppen

## Screenshots
- Not provided (text-only content change)

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ce4a5f3c832ab8136cbd29871047)