### PR TITLE
Optimize hero layout for tablets

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -204,6 +204,22 @@ const rhythm = [
 		backdrop-filter: blur(8px);
 	}
 
+	@media (max-width: 1024px) {
+		.hero {
+			grid-template-columns: 1fr;
+			gap: 18px;
+		}
+
+		.hero h1 {
+			font-size: clamp(30px, 5.4vw, 40px);
+			line-height: 1.2;
+		}
+
+		.panel {
+			padding: 16px;
+		}
+	}
+
 	.card-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));


### PR DESCRIPTION
## Summary
- stack the home hero content on tablets to prevent the heading from being clipped
- reduce hero heading size/line-height for medium screens and tighten panel padding for better fit

## Testing
- npm run build

## Issues
Fixes #5

## Screenshots
- Unable to capture in this environment (browser tool unavailable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692366408e28832aaf4d0d715363d56a)